### PR TITLE
Fix abstime parsing

### DIFF
--- a/Database/HDBC/PostgreSQL/PTypeConv.hsc
+++ b/Database/HDBC/PostgreSQL/PTypeConv.hsc
@@ -88,7 +88,7 @@ oidToColType oid =
       #{const PG_TYPE_FLOAT4} -> SqlRealT
       #{const PG_TYPE_FLOAT8} -> SqlFloatT
       #{const PG_TYPE_DATE} -> SqlDateT
-      #{const PG_TYPE_ABSTIME} -> SqlTimestampT
+      #{const PG_TYPE_ABSTIME} -> SqlTimestampWithZoneT
 
       #{const PG_TYPE_DATETIME} -> SqlTimestampWithZoneT
       #{const PG_TYPE_TIMESTAMP_NO_TMZONE} -> SqlTimestampT


### PR DESCRIPTION
This should be pretty self-explanatory from the comment.   I haven't taken the time to test it with older versions of Postgres,  but abstime is fairly obsolete at this point and it's use in new development is not recommended.
