### PR TITLE
Set pointer to NULL after closing it

### DIFF
--- a/hdbc-postgresql-helper.c
+++ b/hdbc-postgresql-helper.c
@@ -31,6 +31,7 @@ void PQfinish_app(finalizeonce *conn) {
   if (conn->isfinalized)
     return;
   PQfinish((PGconn *) (conn->encapobj));
+  conn->encapobj = NULL;
   conn->isfinalized = 1;
 }
 


### PR DESCRIPTION
This prevents memory corruption in double-close scenario.
