### PR TITLE
This adds support for escaped questionmarks which is important for some queries.

### DIFF
--- a/Database/HDBC/PostgreSQL/Parser.hs
+++ b/Database/HDBC/PostgreSQL/Parser.hs
@@ -48,9 +48,14 @@ qmark = do char '?'
            updateState (+1)
            return $ "$" ++ show n
 
+escapedQmark :: GenParser Char st [Char]
+escapedQmark = do try (char '\\' >> char '?')
+                  return "?"
+
 statement :: (Num st, Show st) => GenParser Char st [Char]
 statement = 
-    do s <- many ((try qmark) <|>
+    do s <- many ((try escapedQmark) <|>
+                  (try qmark) <|>
                   (try comment) <|>
                   (try literal) <|>
                   (try qidentifier) <|>


### PR DESCRIPTION
This is necessary to write queries of the form:

```
SELECT id FROM nodes WHERE tags ? 'name';
```

Here the table 'nodes' has a collumn of type HStore named 'tags'.
The question mark is an opperator that check if the key 'name' exists in
the HStore collumn.

To write the above query in HDBC:

```
quickQuery' conn "SELECT id FROM nodes WHERE tags \\? 'name'" []
```

For more information about HStore collumns, check section F.13.2 on
http://www.postgresql.org/docs/8.4/static/hstore.html
