### PR TITLE
Parser module uses hand-written parser (much faster). Get rid of parsec

### DIFF
--- a/Database/HDBC/PostgreSQL/Statement.hsc
+++ b/Database/HDBC/PostgreSQL/Statement.hsc
@@ -45,15 +45,8 @@ newSth indbo mchildren query =
        newstomv <- newMVar Nothing
        newnextrowmv <- newMVar (-1)
        newcoldefmv <- newMVar []
-       usequery <- case convertSQL query of
-                      Left errstr -> throwSqlError $ SqlError
-                                      {seState = "",
-                                       seNativeError = (-1),
-                                       seErrorMsg = "hdbc prepare: " ++
-                                                    show errstr}
-                      Right converted -> return converted
        let sstate = SState {stomv = newstomv, nextrowmv = newnextrowmv,
-                            dbo = indbo, squery = usequery,
+                            dbo = indbo, squery = convertSQL query,
                             coldefmv = newcoldefmv}
        let retval =
                 Statement {execute = fexecute sstate,

--- a/HDBC-postgresql.cabal
+++ b/HDBC-postgresql.cabal
@@ -35,7 +35,7 @@ Library
     Database.HDBC.PostgreSQL.PTypeConv,
     Database.HDBC.PostgreSQL.ErrorCodes
   Extensions: ExistentialQuantification, ForeignFunctionInterface
-  Build-Depends: base >= 3 && < 5, mtl, HDBC>=2.2.0, parsec, utf8-string,
+  Build-Depends: base >= 3 && < 5, mtl, HDBC>=2.2.0, utf8-string,
                  bytestring, old-time, old-locale, time, convertible
   if impl(ghc >= 6.9)
     Build-Depends: base >= 4
@@ -47,8 +47,8 @@ Library
 Executable runtests
    if flag(buildtests)
       Buildable: True
-      Build-Depends: HUnit, QuickCheck, testpack, containers,
-                     convertible, time, old-locale, parsec, utf8-string,
+      Build-Depends: HUnit, QuickCheck < 2, testpack, containers,
+                     convertible, time, old-locale, utf8-string,
                      bytestring, old-time, base, HDBC>=2.2.6
    else
       Buildable: False


### PR DESCRIPTION
this makes prepare function much faster (and much less garbagy). I've tested the new implementation with the old one using a few runs of 10^6 testcases generated with quickcheck
