### PR TITLE
switch from Prelude.catch to Control.Exception.catch (fix for ghc-7.6)

### DIFF
--- a/testsrc/TestSbasics.hs
+++ b/testsrc/TestSbasics.hs
@@ -4,7 +4,7 @@ import Data.List
 import Database.HDBC
 import TestUtils
 import System.IO
-import Control.Exception hiding (catch)
+import Control.Exception
 
 openClosedb = sqlTestCase $ 
     do dbh <- connectDB
@@ -142,7 +142,7 @@ testWithTransaction = dbTestCase (\dbh ->
        -- Let's try a rollback.
        catch (withTransaction dbh (\_ -> do sExecuteMany sth rows
                                             fail "Foo"))
-             (\_ -> return ())
+             ((\_ -> return ()) :: SomeException -> IO ())
        sExecute qrysth []
        sFetchAllRows qrysth >>= (assertEqual "rollback" [[Just "0"]])
 

--- a/testsrc/TestSbasics.hs
+++ b/testsrc/TestSbasics.hs
@@ -140,7 +140,8 @@ testWithTransaction = dbTestCase (\dbh ->
        sFetchAllRows qrysth >>= (assertEqual "initial commit" [[Just "0"]])
        
        -- Let's try a rollback.
-       catch (withTransaction dbh (\_ -> do sExecuteMany sth rows
+       Control.Exception.catch (withTransaction dbh (\_ -> do
+                                            sExecuteMany sth rows
                                             fail "Foo"))
              ((\_ -> return ()) :: SomeException -> IO ())
        sExecute qrysth []

--- a/testsrc/Testbasics.hs
+++ b/testsrc/Testbasics.hs
@@ -138,7 +138,8 @@ testWithTransaction = dbTestCase (\dbh ->
        fetchAllRows qrysth >>= (assertEqual "initial commit" [[toSql "0"]])
        
        -- Let's try a rollback.
-       catch (withTransaction dbh (\_ -> do executeMany sth rows
+       Control.Exception.catch (withTransaction dbh (\_ -> do
+                                            executeMany sth rows
                                             fail "Foo"))
              ((\ _ -> return ()) :: SomeException -> IO ())
        execute qrysth []

--- a/testsrc/Testbasics.hs
+++ b/testsrc/Testbasics.hs
@@ -3,7 +3,7 @@ import Test.HUnit
 import Database.HDBC
 import TestUtils
 import System.IO
-import Control.Exception hiding (catch)
+import Control.Exception
 
 openClosedb = sqlTestCase $ 
     do dbh <- connectDB
@@ -140,7 +140,7 @@ testWithTransaction = dbTestCase (\dbh ->
        -- Let's try a rollback.
        catch (withTransaction dbh (\_ -> do executeMany sth rows
                                             fail "Foo"))
-             (\_ -> return ())
+             ((\ _ -> return ()) :: SomeException -> IO ())
        execute qrysth []
        fetchAllRows qrysth >>= (assertEqual "rollback" [[SqlString "0"]])
 


### PR DESCRIPTION
This fixes the package for ghc-7.6.

I am unexperienced when it comes to git branches. I was working on something else (prepared statements) in the master branch of my fork, so I created a branch based on the current version from hdbc/hdbc-postgresql called "ghc-7.6-fix". I hope this is ok and I did everything correctly.
