### PR TITLE
GHC 7.10 compability

### DIFF
--- a/Database/HDBC/PostgreSQL/Statement.hsc
+++ b/Database/HDBC/PostgreSQL/Statement.hsc
@@ -22,7 +22,13 @@ import Database.HDBC.PostgreSQL.Parser(convertSQL)
 import Database.HDBC.DriverUtils
 import Database.HDBC.PostgreSQL.PTypeConv
 import Data.Time.Format
+
+#if MIN_VERSION_time(1,5,0)
+import System.Locale hiding (defaultTimeLocale)
+#else
 import System.Locale
+#endif
+
 
 l :: Monad m => t -> m ()
 l _ = return ()

--- a/HDBC-postgresql.cabal
+++ b/HDBC-postgresql.cabal
@@ -36,7 +36,7 @@ Library
     Database.HDBC.PostgreSQL.ErrorCodes
   Extensions: ExistentialQuantification, ForeignFunctionInterface
   Build-Depends: base >= 3 && < 5, mtl, HDBC>=2.2.0, parsec, utf8-string,
-                 bytestring, old-time, old-locale, time, convertible
+                 bytestring, old-time, old-locale, time, convertible >= 1.1.0.0
   if impl(ghc >= 6.9)
     Build-Depends: base >= 4
   Extra-Libraries: pq
@@ -48,7 +48,7 @@ Executable runtests
    if flag(buildtests)
       Buildable: True
       Build-Depends: HUnit, QuickCheck, testpack, containers,
-                     convertible, time, old-locale, parsec, utf8-string,
+                     convertible >= 1.1.0.0, time, old-locale, parsec, utf8-string,
                      bytestring, old-time, base, HDBC>=2.2.6
    else
       Buildable: False


### PR DESCRIPTION
Two small fixes to make hdbc-postgresql build with GHC 7.10.1 RC3. The convertible lower bound is not strictly necessary because current HDBC versions already have the lower bound. It seems to be a good idea though as earlier convertible versions do not build with GHC 7.10.

Note that currently the HDBC dependency does not build in the Hackage-released version 2.4.0.0, only with git HEAD.