### PR TITLE
add custom-setup to fix cabal v2-build.

### DIFF
--- a/HDBC-postgresql.cabal
+++ b/HDBC-postgresql.cabal
@@ -20,6 +20,9 @@ Stability: Stable
 Build-Type: Custom
 Cabal-Version: >=1.8
 
+custom-setup
+  setup-depends: Cabal >= 1.8 && < 3.1, base < 5
+
 Flag splitBase
   description: Choose the new smaller, split-up package.
 Flag buildtests


### PR DESCRIPTION
`cabal v2-build` fails like bellow.
This patch fixes this issue.

To allow `Cabal 3` PR ( https://github.com/hdbc/hdbc-postgresql/pull/49 ),
this patch specifies `3.1` as the upper bound of `Cabal` version.

I found this is a regression issue ( https://github.com/haskell/cabal/issues/5618 ) fixed in rev 1 of 2.3.2.5 ( http://hackage.haskell.org/package/HDBC-postgresql-2.3.2.5/revisions/ ).

```
% cabal v2-build
Resolving dependencies...
cabal: Could not resolve dependencies:
[__0] trying: HDBC-postgresql-2.3.2.6 (user goal)
[__1] next goal: HDBC-postgresql:setup.Cabal (dependency of HDBC-postgresql)
[__1] rejecting: HDBC-postgresql:setup.Cabal-2.4.0.1/installed-2.4...
(conflict: HDBC-postgresql => HDBC-postgresql:setup.Cabal>=1.8 && <1.25)
[__1] rejecting: HDBC-postgresql:setup.Cabal-3.0.0.0 (constraint from maximum
version of Cabal used by Setup.hs requires <2.6)
[__1] rejecting: HDBC-postgresql:setup.Cabal-2.4.1.0,
HDBC-postgresql:setup.Cabal-2.4.0.1, HDBC-postgresql:setup.Cabal-2.4.0.0
(conflict: HDBC-postgresql => HDBC-postgresql:setup.Cabal>=1.8 && <1.25)
[__1] rejecting: HDBC-postgresql:setup.Cabal-2.2.0.1,
HDBC-postgresql:setup.Cabal-2.2.0.0, HDBC-postgresql:setup.Cabal-2.0.1.1,
HDBC-postgresql:setup.Cabal-2.0.1.0, HDBC-postgresql:setup.Cabal-2.0.0.2,
HDBC-postgresql:setup.Cabal-1.24.2.0, HDBC-postgresql:setup.Cabal-1.24.0.0,
HDBC-postgresql:setup.Cabal-1.22.8.0, HDBC-postgresql:setup.Cabal-1.22.7.0,
HDBC-postgresql:setup.Cabal-1.22.6.0, HDBC-postgresql:setup.Cabal-1.22.5.0,
HDBC-postgresql:setup.Cabal-1.22.4.0, HDBC-postgresql:setup.Cabal-1.22.3.0,
HDBC-postgresql:setup.Cabal-1.22.2.0, HDBC-postgresql:setup.Cabal-1.22.1.1,
HDBC-postgresql:setup.Cabal-1.22.1.0, HDBC-postgresql:setup.Cabal-1.22.0.0,
HDBC-postgresql:setup.Cabal-1.20.0.4, HDBC-postgresql:setup.Cabal-1.20.0.3,
HDBC-postgresql:setup.Cabal-1.20.0.2, HDBC-postgresql:setup.Cabal-1.20.0.1,
HDBC-postgresql:setup.Cabal-1.20.0.0, HDBC-postgresql:setup.Cabal-1.18.1.7,
HDBC-postgresql:setup.Cabal-1.18.1.6, HDBC-postgresql:setup.Cabal-1.18.1.5,
HDBC-postgresql:setup.Cabal-1.18.1.4, HDBC-postgresql:setup.Cabal-1.18.1.3,
HDBC-postgresql:setup.Cabal-1.18.1.2, HDBC-postgresql:setup.Cabal-1.18.1.1,
HDBC-postgresql:setup.Cabal-1.18.1, HDBC-postgresql:setup.Cabal-1.18.0,
HDBC-postgresql:setup.Cabal-1.16.0.3, HDBC-postgresql:setup.Cabal-1.16.0.2,
HDBC-postgresql:setup.Cabal-1.16.0.1, HDBC-postgresql:setup.Cabal-1.16.0,
HDBC-postgresql:setup.Cabal-1.14.0, HDBC-postgresql:setup.Cabal-1.12.0,
HDBC-postgresql:setup.Cabal-1.10.2.0, HDBC-postgresql:setup.Cabal-1.10.1.0,
HDBC-postgresql:setup.Cabal-1.10.0.0, HDBC-postgresql:setup.Cabal-1.8.0.6,
HDBC-postgresql:setup.Cabal-1.8.0.4, HDBC-postgresql:setup.Cabal-1.8.0.2,
HDBC-postgresql:setup.Cabal-1.6.0.3, HDBC-postgresql:setup.Cabal-1.6.0.2,
HDBC-postgresql:setup.Cabal-1.6.0.1, HDBC-postgresql:setup.Cabal-1.4.0.2,
HDBC-postgresql:setup.Cabal-1.4.0.1, HDBC-postgresql:setup.Cabal-1.4.0.0,
HDBC-postgresql:setup.Cabal-1.2.4.0, HDBC-postgresql:setup.Cabal-1.2.3.0,
HDBC-postgresql:setup.Cabal-1.2.2.0, HDBC-postgresql:setup.Cabal-1.2.1,
HDBC-postgresql:setup.Cabal-1.1.6, HDBC-postgresql:setup.Cabal-1.24.1.0
(constraint from minimum version of Cabal used by Setup.hs requires >=2.4)
[__1] fail (backjumping, conflict set: HDBC-postgresql,
HDBC-postgresql:setup.Cabal)
After searching the rest of the dependency tree exhaustively, these were the
goals I've had most trouble fulfilling: HDBC-postgresql:setup.Cabal,
HDBC-postgresql
```