### PR TITLE
Allow Cabal 3.4 series

### DIFF
--- a/HDBC-postgresql.cabal
+++ b/HDBC-postgresql.cabal
@@ -21,7 +21,7 @@ Build-Type: Custom
 Cabal-Version: >=1.10
 
 custom-setup
-  setup-depends: Cabal >= 1.8 && < 3.3, base < 5
+  setup-depends: Cabal >= 1.8 && < 3.5, base < 5
 
 Flag splitBase
   description: Choose the new smaller, split-up package.


### PR DESCRIPTION
I ran "cabal build" with this patch, and it compiles fine. So I think that is sufficient to say that it would be OK to bump this? If there are any other tests I can do, let me know. I'd like to use Cabal 3.4 like I can with almost any other package.