### PR TITLE
Use UTC for new sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* The library now uses the UTC timezone for new sessions. A user of the library must set a timezone manually if they want to use a different one.
+
 ## 2.5.0.0
 
 * Add explicit call to `finalizeForeignPtr` on connection disconnects. Ensures disconnects happen at the moment close is call, as opposed to when the GC frees the ForeignPtr.

--- a/Database/HDBC/PostgreSQL/Connection.hsc
+++ b/Database/HDBC/PostgreSQL/Connection.hsc
@@ -98,6 +98,7 @@ mkConn auto_transaction args conn = withConn conn $
                             Impl.getTables = fgetTables conn children,
                             Impl.describeTable = fdescribeTable conn children}
        _ <- quickQuery rconn "SET client_encoding TO utf8;" []
+       _ <- quickQuery rconn "SET timezone TO UTC;" []
        return rconn
 
 -- | Connect to a PostgreSQL server,  and automatically disconnect


### PR DESCRIPTION
Fixes #55 . It doesn't *really* fix it, but you noted that this workaround was acceptable. The correct fix would be to fix the time library such that it can have this granularity in the timezone offsets. I created [an issue there](https://github.com/haskell/time/issues/174) to discuss that fix, which is much more involved since there is currently no type for these offsets. But they don't want to fix it in the *time* library.