### PR TITLE
Remove unnecessary test dependency

### DIFF
--- a/HDBC-postgresql.cabal
+++ b/HDBC-postgresql.cabal
@@ -59,7 +59,7 @@ Library
 Executable runtests
    if flag(buildtests)
       Buildable: True
-      Build-Depends: HUnit, QuickCheck, testpack, containers,
+      Build-Depends: HUnit, QuickCheck, containers,
                      convertible, parsec, utf8-string,
                      bytestring, old-time, base >= 4.6 && < 5.0, HDBC>=2.2.6
       if flag(minTime15)


### PR DESCRIPTION
This dependency doesn't build, and it isn't needed. So we may as well remove it. I tested running the tests using `cabal run runtests -fbuildtests`. With this patch, they pass. Without this patch, they cannot be run on GHC 8.6.5 from ghcup with a cabal snapshot from today.