### PR TITLE
Remove upper Cabal bound

### DIFF
--- a/HDBC-postgresql.cabal
+++ b/HDBC-postgresql.cabal
@@ -21,7 +21,7 @@ Build-Type: Custom
 Cabal-Version: >=1.10
 
 custom-setup
-  setup-depends: Cabal >= 1.8 && < 3.5, base < 5
+  setup-depends: Cabal >= 1.8, base < 5
 
 Flag splitBase
   description: Choose the new smaller, split-up package.


### PR DESCRIPTION
This enables building with the 3.6 series of Cabal-install.

The upper bound was originally added in commit fefb075c by @khibino. I am not sure whether it was ever necessary to have an upper bound. Cabal-install releases are usually backwards compatible as far as I know. So I'd suggest we just remove the upper bound. We can put it back if a future Cabal-install release doesn't build HDBC-postgresql.