### PR TITLE
Allow time 1.10, 1.11, 1.12, 1.13 series

### DIFF
--- a/HDBC-postgresql.cabal
+++ b/HDBC-postgresql.cabal
@@ -45,7 +45,7 @@ Library
   Build-Depends: base >= 3 && < 5, mtl, HDBC>=2.2.0, parsec, utf8-string,
                  bytestring, old-time, convertible
   if flag(minTime15)
-    Build-Depends: time >= 1.5 && < 1.10
+    Build-Depends: time >= 1.5 && < 1.14
     CPP-Options: -DMIN_TIME_15
   else
     Build-Depends: time < 1.5, old-locale
@@ -63,7 +63,7 @@ Executable runtests
                      convertible, parsec, utf8-string,
                      bytestring, old-time, base >= 4.6 && < 5.0, HDBC>=2.2.6
       if flag(minTime15)
-        Build-Depends: time >= 1.5 && < 1.9
+        Build-Depends: time >= 1.5 && < 1.14
         CPP-Options: -DMIN_TIME_15
       else
         Build-Depends: time < 1.5, old-locale


### PR DESCRIPTION
Tested using

    cabal build --constraint='time==1.10'
    cabal build --constraint='time==1.11.1.2'
    cabal build --constraint='time==1.12.1'

Not tested with time 1.13 since that one was revoked. But we may as well allow
it in this range, such that we know it was already tested next time we bump
this.
