### PR TITLE
Test roundtripping date from first century

### DIFF
--- a/HDBC-postgresql.cabal
+++ b/HDBC-postgresql.cabal
@@ -45,7 +45,7 @@ Library
   Build-Depends: base >= 3 && < 5, mtl, HDBC>=2.2.0, parsec, utf8-string,
                  bytestring, old-time, convertible
   if flag(minTime15)
-    Build-Depends: time >= 1.5 && < 1.10
+    Build-Depends: time >= 1.5 && < 1.14
     CPP-Options: -DMIN_TIME_15
   else
     Build-Depends: time < 1.5, old-locale
@@ -63,7 +63,7 @@ Executable runtests
                      convertible, parsec, utf8-string,
                      bytestring, old-time, base >= 4.6 && < 5.0, HDBC>=2.2.6
       if flag(minTime15)
-        Build-Depends: time >= 1.5 && < 1.9
+        Build-Depends: time >= 1.5 && < 1.14
         CPP-Options: -DMIN_TIME_15
       else
         Build-Depends: time < 1.5, old-locale


### PR DESCRIPTION
Since it is the HDBC library that is responsible for encoding dates, we only
add the test here, since it is using PostgreSQL specific syntax.

Note how I based this on top of the 'time' bump PR. This is because that PR is
necessary to actually run this using `cabal run -f buildtests`.
